### PR TITLE
Update SonataMenuBlockService.php

### DIFF
--- a/src/block/SonataMenuBlockService.php
+++ b/src/block/SonataMenuBlockService.php
@@ -53,7 +53,7 @@ final class SonataMenuBlockService extends AbstractBlockService implements Edita
         $this->request = $requestStack->getCurrentRequest();
     }
 
-    public function execute(BlockContextInterface $blockContext, Response $response = null): Response
+    public function execute(BlockContextInterface $blockContext, ?Response $response = null): Response
     {
         $cms = $this->cmsSelector->retrieve();
         $siteId = $cms->getCurrentPage()->getSite()->getId();


### PR DESCRIPTION
prevent error: Deprecated: Partitech\SonataMenu\block\SonataMenuBlockService::execute(): Implicitly marking parameter $response as nullable is deprecated, the explicit nullable type must be used instead in /var/www/vendor/partitech/sonata-menu-bundle/src/block/SonataMenuBlockService.php on line 56